### PR TITLE
Added limit param to contentful api request

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,6 @@ preprocessors:
     contentModel: exampleModel1
   - collection: /content/exampleModel2/
     contentModel: exampleModel2
+  limit: 100
 ```
+Note: Limit value is optional, 0 or none will set it to its default value wich is 100. And can not be greater than 1000 or the contentful api will throw a BadRequestError.

--- a/contentful_ext/contentful_ext.py
+++ b/contentful_ext/contentful_ext.py
@@ -26,6 +26,7 @@ class ContentfulPreprocessor(grow.Preprocessor):
         space = messages.StringField(2)
         keys = messages.MessageField(KeyMessage, 3)
         bind = messages.MessageField(BindingMessage, 4, repeated=True)
+        limit = messages.IntegerField(5)
 
     def _parse_field(self, field):
         if isinstance(field, resources.Asset):
@@ -85,7 +86,10 @@ class ContentfulPreprocessor(grow.Preprocessor):
             self.pod.logger.info('Deleted -> {}'.format(pod_path))
 
     def run(self, *args, **kwargs):
-        entries = self.cda.fetch(resources.Entry).all()
+        request = self.cda.fetch(resources.Entry)
+        if self.config.limit:
+            request.params['limit'] = self.config.limit
+        entries = request.all()
         for binding in self.config.bind:
             self.bind_collection(entries, binding.collection,
                                  binding.contentModel)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='grow-ext-contentful',
-    version='1.0.0',
+    version='1.0.1',
     license='MIT',
     author='Grow Authors',
     author_email='hello@grow.io',


### PR DESCRIPTION
Hi there,

While using grow-ext-contentful, I had problems when I needed more then the default 100 entries returned by contentful. So I made a few changes to add limit as a config param. Hope it could be usefull for more users.

Ty.