### PR TITLE
✨ Enable secret credentials via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ preprocessors:
 - kind: contentful
   autorun: true
 
-  space: exampleContentfulSpaceId
-  access_token: exampleContentfulProductionKey
+  # If you don't want to share your Contentful space_id and access_token
+  # you can export them as local environment variables and inject them with ${...}
+
+  space: exampleContentfulSpaceId || ${CTF_SPACE_ID}
+  access_token: exampleContentfulProductionKey || ${CTF_ACCESS_TOKEN}
 
   # Uncomment to use the `preview` API.
   # access_token: exampleContentfulPreviewKey

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 Contentful extension for Grow. Binds Contentful collections to Grow
 collections.
 
+Customized Jung von Matt version with extra functionality!
+
+
 ## Concept
 
 - Binds Contentful collections to Grow collections.
@@ -35,6 +38,11 @@ preprocessors:
   # Uncomment to use the `preview` API.
   # access_token: exampleContentfulPreviewKey
   # preview: true
+
+  # When the contet structure has references like teasers that blow up the page yaml
+  # uncomment and edit the following lines to skip those fields in related entries
+  # skip_related_fields:
+  # - teaser
 
   bind:
   - collection: /content/exampleModel1/

--- a/contentful_ext/contentful_ext.py
+++ b/contentful_ext/contentful_ext.py
@@ -38,6 +38,7 @@ class ContentfulPreprocessor(grow.Preprocessor):
         preview = messages.BooleanField(6, default=False)
         rewrite_locales = messages.MessageField(RewriteLocalesMessage, 7, repeated=True)
         variation = messages.MessageField(VariationMessage, 8)
+        default_locale = messages.StringField(9, default='en-US')
 
     def normalize_locale(self, locale):
         # Converts a Contentful locale to a Grow (ICU) locale.
@@ -196,11 +197,13 @@ class ContentfulPreprocessor(grow.Preprocessor):
                     self.config.space,
                     access_token,
                     api_url=api_url,
+                    default_locale=self.config.default_locale,
                     reuse_entries=True,
                     max_include_resolution_depth=20)
         return contentful.Client(
                 self.config.space,
                 access_token,
+                default_locale=self.config.default_locale,
                 reuse_entries=True,
                 max_include_resolution_depth=20)
 

--- a/contentful_ext/contentful_ext.py
+++ b/contentful_ext/contentful_ext.py
@@ -119,6 +119,10 @@ class ContentfulPreprocessor(grow.Preprocessor):
         result = yaml.dump(fields, default_flow_style=False)
         fields = yaml.load(result)
 
+        # Make sure fields still contain _content_type and _id
+        fields['_content_type'] = entry.sys.get('content_type', {}).id
+        fields['_id'] = entry.sys.get('id')
+
         # Retrieve the key used for the basename from the fields, otherwise use
         # the enry's sys.id.
         normalized_key = fields.get(key) if key else entry.sys['id']

--- a/contentful_ext/contentful_ext.py
+++ b/contentful_ext/contentful_ext.py
@@ -5,6 +5,7 @@ import datetime
 import grow
 import os
 import yaml
+from yaml.loader import UnsafeLoader
 
 
 class BindingMessage(messages.Message):
@@ -117,7 +118,7 @@ class ContentfulPreprocessor(grow.Preprocessor):
         fields = entry.fields()
         fields = _tag_localized_fields(entry, fields, tag_built_ins=True)
         result = yaml.dump(fields, default_flow_style=False)
-        fields = yaml.load(result)
+        fields = yaml.load(result, Loader=UnsafeLoader)
 
         # Make sure fields still contain _content_type and _id
         fields['_content_type'] = entry.sys.get('content_type', {}).id

--- a/contentful_ext/contentful_ext.py
+++ b/contentful_ext/contentful_ext.py
@@ -40,6 +40,7 @@ class ContentfulPreprocessor(grow.Preprocessor):
         rewrite_locales = messages.MessageField(RewriteLocalesMessage, 7, repeated=True)
         variation = messages.MessageField(VariationMessage, 8)
         default_locale = messages.StringField(9, default='en-US')
+        environment = messages.StringField(10, default='MASTER')
 
     def normalize_locale(self, locale):
         # Converts a Contentful locale to a Grow (ICU) locale.
@@ -204,12 +205,14 @@ class ContentfulPreprocessor(grow.Preprocessor):
                     api_url=api_url,
                     default_locale=self.config.default_locale,
                     reuse_entries=True,
+                    environment=self.config.environment,
                     max_include_resolution_depth=20)
         return contentful.Client(
                 self.config.space,
                 access_token,
                 default_locale=self.config.default_locale,
                 reuse_entries=True,
+                environment=self.config.environment,
                 max_include_resolution_depth=20)
 
     def _normalize_path(self, path):

--- a/contentful_ext/contentful_ext.py
+++ b/contentful_ext/contentful_ext.py
@@ -40,7 +40,7 @@ class ContentfulPreprocessor(grow.Preprocessor):
         rewrite_locales = messages.MessageField(RewriteLocalesMessage, 7, repeated=True)
         variation = messages.MessageField(VariationMessage, 8)
         default_locale = messages.StringField(9, default='en-US')
-        environment = messages.StringField(10, default='MASTER')
+        environment = messages.StringField(10, default='master')
 
     def normalize_locale(self, locale):
         # Converts a Contentful locale to a Grow (ICU) locale.

--- a/contentful_ext/contentful_ext.py
+++ b/contentful_ext/contentful_ext.py
@@ -71,7 +71,7 @@ class ContentfulPreprocessor(grow.Preprocessor):
                     all_locales.add(tag_locale)
                     tagged_key = '{}@{}'.format(key, tag_locale)
                     # Support localized built-ins.
-                    if tag_built_ins and key in ['title', 'category']:
+                    if tag_built_ins and key in ['title', 'category', 'slug']:
                         tagged_key = '${}'.format(tagged_key)
                     localized_fields = obj.fields(locale)
                     if not localized_fields or key not in localized_fields:

--- a/contentful_ext/contentful_ext.py
+++ b/contentful_ext/contentful_ext.py
@@ -40,7 +40,6 @@ class ContentfulPreprocessor(grow.Preprocessor):
         rewrite_locales = messages.MessageField(RewriteLocalesMessage, 7, repeated=True)
         variation = messages.MessageField(VariationMessage, 8)
         default_locale = messages.StringField(9, default='en-US')
-        environment = messages.StringField(10, default='MASTER')
 
     def normalize_locale(self, locale):
         # Converts a Contentful locale to a Grow (ICU) locale.
@@ -205,14 +204,12 @@ class ContentfulPreprocessor(grow.Preprocessor):
                     api_url=api_url,
                     default_locale=self.config.default_locale,
                     reuse_entries=True,
-                    environment=self.config.environment,
                     max_include_resolution_depth=20)
         return contentful.Client(
                 self.config.space,
                 access_token,
                 default_locale=self.config.default_locale,
                 reuse_entries=True,
-                environment=self.config.environment,
                 max_include_resolution_depth=20)
 
     def _normalize_path(self, path):


### PR DESCRIPTION
With the custom pattern `${<string>}` it is possible to inject a specific environment variable into the podspec.yaml

This is useful if you don't want to share your contentful space id and access token on public repositories.